### PR TITLE
Added Preliminary Blender (2.8 Beta) Recipe.

### DIFF
--- a/recipes/Blender.yml
+++ b/recipes/Blender.yml
@@ -2,8 +2,10 @@ app: Blender
 
 ingredients:
   script:
-    - wget -c https://builder.blender.org/download/blender-2.80-91a155833e59-linux-glibc224-x86_64.tar.bz2
-    - ls blender-*.tar.bz2 | cut -d - -f 2 | sed -e 's|.tar.bz2||g' > VERSION
+    - URL1=$(wget -q "https://www.blender.org/download/" -O - | grep linux-glibc | grep x86_64 | head -n 1 | cut -d '"' -f 4)
+    - URL=$(wget -q "$URL1" -O - | grep tar.bz2 | head -n 1 | cut -d '"' -f 2)
+    - echo "$URL" | cut -d "-" -f 3 > VERSION
+    - wget "$URL"
     - mkdir -p blender
     - tar xf blender*.tar.bz2 -C ./blender --strip-components=1
 

--- a/recipes/Blender.yml
+++ b/recipes/Blender.yml
@@ -1,0 +1,26 @@
+app: Blender
+
+ingredients:
+  script:
+    - wget -c https://builder.blender.org/download/blender-2.80-91a155833e59-linux-glibc224-x86_64.tar.bz2
+    - ls blender-*.tar.bz2 | cut -d - -f 2 | sed -e 's|.tar.bz2||g' > VERSION
+    - mkdir -p blender
+    - tar xf blender*.tar.bz2 -C ./blender --strip-components=1
+
+script:
+  - cp -r ../blender/* ./usr/bin/;
+  - cp ./usr/bin/icons/scalable/apps/blender.svg .
+  -
+  - cat > blender.desktop <<\EOF
+  - [Desktop Entry]
+  - Name=Blender
+  - GenericName=3D modeler
+  - Comment=3D modeling, animation, rendering and post-production
+  - Keywords=3d;cg;modeling;animation;painting;sculpting;texturing;video editing;video tracking;rendering;render engine;cycles;game engine;python;
+  - Exec=blender %f
+  - Icon=blender
+  - Terminal=false
+  - Type=Application
+  - Categories=Graphics;3DGraphics;
+  - MimeType=application/x-blender;
+  - EOF


### PR DESCRIPTION
So I was looking into this repository because I thought it seemed interesting to have a means of converting archives / debs to appimages, but ran into a few problems with something I thought would be easy. (Blender)

Basically, blender.org currently uses redirection techniques for the download pages that makes it hard to parse for a direct link. Because of this, I decided to use a direct link to blender 2.8 for the time being. Ideally, this would actually link to the executable for 2.79 available on the [download page](https://www.blender.org/download/) but currently uses a link to the blender 2.8 beta from [this page](https://builder.blender.org/download/) instead. 

If anybody has the know-how of dealing with this type of download-redirection, that would be very useful and would like to fix this recipe.  