### PR TITLE
Improved support for Sayonara music player.

### DIFF
--- a/recipes/Sayonara.yml
+++ b/recipes/Sayonara.yml
@@ -3,10 +3,13 @@ binpatch: true
 
 ingredients:
   dist: trusty
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe multiverse
-  ppas: 
+  ppas:
     - lucioc/sayonara
-
-# App fails playing with
-# Error: Engine: src creation failed
+  script:
+    - URL1=$(wget -q "https://sayonara-player.com/downloads.php" -O - | grep amd64 | tail -n 1 | cut -d '"' -f 2 )
+    - echo "$URL1" | cut -d '_' -f 2 | cut -d '-' -f 1 > VERSION
+    - URL='https://sayonara-player.com/'
+    - URL+=$URL1
+    - wget -c "$URL"


### PR DESCRIPTION
This patch allows the Sayonara recipe to download and install packages properly. Previous version of this recipe failed to build when I tested it, so I took some time to make some improvements. No problems with playback so far.

This now fetches the debian package from the website which should help keep it up to date with the latest versions available for download. A custom PPA is required for the deb file to function properly. 