### PR TITLE
Add logic to parse each section when linting

### DIFF
--- a/appdir-lint.sh
+++ b/appdir-lint.sh
@@ -48,28 +48,24 @@ num_keys_fatal () {
   do
       if [[ $key == \[*\] ]] ; then
         # in a new section; confirm we saw the key once in [Desktop Entry]
-        if [[ "${section}" == "[Desktop Entry]" ]] ; then
-          seen_key="seen__${section}__${1}"
+        if [[ "${raw_section}" == "[Desktop Entry]" ]] ; then
+          local seen_key="seen__${section}__${1}"
           if [[ "${!seen_key}" != "1" ]] ; then
             fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
           fi
         fi
-        raw_section=$key
-        section="${key//[\[\]\- ]/_}"
+        local raw_section=$key
+        local section="${key//[\[\]\- ]/_}"
       elif [[ $key == "$1" ]] ; then
-        seen_key="seen__${section}__${key}"
-        if [[ "${!seen_key}" == "1" ]] ; then
-          fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
-        else
-          printf -v "$seen_key" %s "1"
-        fi
+        local seen_key="seen__${section}__${key}"
+        printf -v "$seen_key" %s "$(( $seen_key + 1 ))"
       fi
   done < "${APPDIR}"/*.desktop
 
 
   # in case there is only one section
   # check for existence of key in [Desktop Entry]
-  seen_key="seen__${section}__${1}"
+  local seen_key="seen__${section}__${1}"
   if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
     fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
   fi
@@ -85,28 +81,24 @@ num_keys_warn () {
   do
       if [[ $key == \[*\] ]] ; then
         # in a new section; confirm we saw the key once in [Desktop Entry]
-        if [[ "${section}" == "[Desktop Entry]" ]] ; then
-          seen_key="seen__${section}__${1}"
+        if [[ "${raw_section}" == "[Desktop Entry]" ]] ; then
+          local seen_key="seen__${section}__${1}"
           if [[ "${!seen_key}" != "1" ]] ; then
             warn "Key $1 is not in .desktop file exactly once in section $raw_section"
           fi
         fi
-        raw_section=$key
-        section="${key//[\[\]\- ]/_}"
+        local raw_section=$key
+        local section="${key//[\[\]\- ]/_}"
       elif [[ $key == "$1" ]] ; then
-        seen_key="seen__${section}__${key}"
-        if [[ "${!seen_key}" == "1" ]] ; then
-          warn "Key $1 is not in .desktop file exactly once in section $raw_section"
-        else
-          printf -v "$seen_key" %s "1"
-        fi
+        local seen_key="seen__${section}__${key}"
+        printf -v "$seen_key" %s "$(( $seen_key + 1 ))"
       fi
   done < "${APPDIR}"/*.desktop
 
 
   # in case there is only one section
   # check for existence of key in [Desktop Entry]
-  seen_key="seen__${section}__${1}"
+  local seen_key="seen__${section}__${1}"
   if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
     warn "Key $1 is not in .desktop file exactly once in section $raw_section"
   fi

--- a/appdir-lint.sh
+++ b/appdir-lint.sh
@@ -47,10 +47,12 @@ num_keys_fatal () {
   while IFS='=' read key val
   do
       if [[ $key == \[*\] ]] ; then
-        # in a new section; confirm we saw the key once in previous section
-        seen_key="seen__${section}__${1}"
-        if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
-          fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+        # in a new section; confirm we saw the key once in [Desktop Entry]
+        if [[ "${section}" == "[Desktop Entry]" ]] ; then
+          seen_key="seen__${section}__${1}"
+          if [[ "${!seen_key}" != "1" ]] ; then
+            fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+          fi
         fi
         raw_section=$key
         section="${key//[\[\]\- ]/_}"
@@ -63,9 +65,12 @@ num_keys_fatal () {
         fi
       fi
   done < "${APPDIR}"/*.desktop
-  # check in last section
+
+
+  # in case there is only one section
+  # check for existence of key in [Desktop Entry]
   seen_key="seen__${section}__${1}"
-  if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+  if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
     fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
   fi
 }
@@ -79,10 +84,12 @@ num_keys_warn () {
   while IFS='=' read key val
   do
       if [[ $key == \[*\] ]] ; then
-        # in a new section; confirm we saw the key once in previous section
-        seen_key="seen__${section}__${1}"
-        if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
-          warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+        # in a new section; confirm we saw the key once in [Desktop Entry]
+        if [[ "${section}" == "[Desktop Entry]" ]] ; then
+          seen_key="seen__${section}__${1}"
+          if [[ "${!seen_key}" != "1" ]] ; then
+            warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+          fi
         fi
         raw_section=$key
         section="${key//[\[\]\- ]/_}"
@@ -95,9 +102,12 @@ num_keys_warn () {
         fi
       fi
   done < "${APPDIR}"/*.desktop
-  # check in last section
+
+
+  # in case there is only one section
+  # check for existence of key in [Desktop Entry]
   seen_key="seen__${section}__${1}"
-  if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+  if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
     warn "Key $1 is not in .desktop file exactly once in section $raw_section"
   fi
 }

--- a/appdir-lint.sh
+++ b/appdir-lint.sh
@@ -47,6 +47,11 @@ num_keys_fatal () {
   while IFS='=' read key val
   do
       if [[ $key == \[*\] ]] ; then
+        # in a new section; confirm we saw the key once in previous section
+        seen_key="seen__${section}__${1}"
+        if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+          fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+        fi
         raw_section=$key
         section="${key//[\[\]\- ]/_}"
       elif [[ $key == "$1" ]] ; then
@@ -58,6 +63,11 @@ num_keys_fatal () {
         fi
       fi
   done < "${APPDIR}"/*.desktop
+  # check in last section
+  seen_key="seen__${section}__${1}"
+  if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+    fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+  fi
 }
 
 desktop-file-validate "${APPDIR}"/*.desktop
@@ -69,6 +79,11 @@ num_keys_warn () {
   while IFS='=' read key val
   do
       if [[ $key == \[*\] ]] ; then
+        # in a new section; confirm we saw the key once in previous section
+        seen_key="seen__${section}__${1}"
+        if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+          warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+        fi
         raw_section=$key
         section="${key//[\[\]\- ]/_}"
       elif [[ $key == "$1" ]] ; then
@@ -80,6 +95,11 @@ num_keys_warn () {
         fi
       fi
   done < "${APPDIR}"/*.desktop
+  # check in last section
+  seen_key="seen__${section}__${1}"
+  if [[ "${section}" != "" && "${!seen_key}" != "1" ]] ; then
+    warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+  fi
 }
 
 # num_keys_fatal Name # This is not a valid test since [Desktop Action ...] sections can also have Name=


### PR DESCRIPTION
Bash 3 compatible change to parse each section of the `.desktop` file separately. This way the file can have multiple keys with the same name as long as they are in different sections/actions.

Example `desktop` file:
```
[Desktop Entry]
Name=VSCodium
Comment=Code Editing. Redefined.
GenericName=Text Editor
Exec=vscodium --unity-launch %F
Icon=vscodium
Type=Application
StartupNotify=false
StartupWMClass=VSCodium
Categories=Utility;TextEditor;Development;IDE;
MimeType=text/plain;inode/directory;
Actions=new-empty-window;
Keywords=vscode;

X-AppImage-Version=1.33.1-1555005058.glibc2.17

[Desktop Action new-empty-window]
Name=New Empty Window
Exec=vscodium --new-window %F
Icon=vscodium

```

The `num_keys_fatal Icon` call would not be fatal for this example since `Icon` is only present once per section. 

Example `desktop` file 2:
```
[Desktop Entry]
Name=VSCodium
Comment=Code Editing. Redefined.
GenericName=Text Editor
Exec=vscodium --unity-launch %F
Icon=vscodium
Type=Application
StartupNotify=false
StartupWMClass=VSCodium
Categories=Utility;TextEditor;Development;IDE;
MimeType=text/plain;inode/directory;
Actions=new-empty-window;
Keywords=vscode;

X-AppImage-Version=1.33.1-1555005058.glibc2.17

[Desktop Action new-empty-window]
Name=New Empty Window
Exec=vscodium --new-window %F
Icon=vscodium
Icon=vscodium2

```

The `num_keys_fatal Icon` call would be fatal for this example since the `Icon` key is present twice. The script would log `Key Icon is not in .desktop file exactly once in section [Desktop Action new-empty-window]`

Tested locally with some `.desktop` files and it works alright.