### PR TITLE
Remove duplicate libcrypt.so.1 entry

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -113,7 +113,6 @@ libharfbuzz.so.0
 # Removing these has worked e.g., for Krita. Feel free to report if
 # you think that some of these should go into AppImages and why.
 libcom_err.so.2
-libcrypt.so.1
 libexpat.so.1
 libgcc_s.so.1
 libglib-2.0.so.0


### PR DESCRIPTION
1ba9538 commented out libcrypt.so.1 because Fedora 30 no longer ships it with glibc.  However, a duplicate entry was not removed, causing some AppImages to still fail to start.