### PR TITLE
Fix the blacklisted files retrieval

### DIFF
--- a/appdir-lint.sh
+++ b/appdir-lint.sh
@@ -138,7 +138,7 @@ else
 fi
 
 
-BLACKLISTED_FILES=$(cat "${HERE}/excludelist" | sed '/^\s*$/d' | sed '/^#.*$/d')
+BLACKLISTED_FILES=$(cat "${HERE}/excludelist" | sed '/^\s*$/d ; /^#.*$/d ; s/\s*#.*$//')
 for FILE in $BLACKLISTED_FILES ; do
   if [ ! -z $(find "${APPDIR}" -name $FILE) ] ; then
     warn "Blacklisted file $FILE found"


### PR DESCRIPTION
To fix:
```shell
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
```
---
In `excludelist`, thoses lines where not properly sanitized:
```
libxcb-dri3.so.0 # https://github.com/AppImage/AppImages/issues/348
```
As a result for this line, `$FILE` was, in that order:
```
libxcb-dri3.so.0
#
https://github.com/AppImage/AppImages/issues/348
```