### PR TITLE
Fix FirefoxDeveloperEdition per installation profile creation

### DIFF
--- a/recipes/FirefoxDeveloperEdition.yml
+++ b/recipes/FirefoxDeveloperEdition.yml
@@ -27,6 +27,8 @@ script:
   - #!/bin/bash
   - HERE="$(dirname "$(readlink -f "${0}")")"
   - cd $HERE/usr
+  - export SNAP_NAME="firefox" # Prevent per installation profiles in ff = 67
+  - export MOZ_LEGACY_PROFILES=1 # Prevent per installation profiles in ff > 68
   - $HERE/usr/bin/firefox $@
   - EOF
   - chmod a+x AppRun


### PR DESCRIPTION
In Firefox 67, each new installation of firefox started being
registered in the ~/.mozilla/firefox/installs.ini file. Each
new installation also created a profile. Profiles store bookmarks
and other user related meta data which users come to expect during
their browsing experience.

These new profiles do not inherit any data from previous profiles.
They exist to support multiple installations of Firefox on the
same system. Installations are identified by hashing the
installation path.

Since AppImages are mounted at /tmp/.mount_XXXXXX, where 'X' are
replaced by some hashed values. This means that Firefox interprets
each new run of a Firefox AppImage to be a new installation,
creating a new profile and not carrying over any of the meta data
a user would expect in their day to day usage of Firefox. This is
a very poor user experience.

There are a number of solutions to this:
1. Allow fixing the mounting location of AppImages.
2. Copying the mounted image into a know location e.g.
   '/tmp/.mount_Firefox<version>DeveloperEdition'
   on each run. Symlinking can't be used as the function for
   hasing the installation path seems to resolve symlinks.
3. Use SNAP_NAME="firefox" to trick Firefox into thinking it is
  running in an Ubuntu Snap environment, which seems to prevent
  this behavior.
4. Use MOZ_LEGACY_PROFILES=1 which is specifically designed to turn
  this behavior off.

While 1 would be ideal as it would support this use case and a few
others brought up in prvious issues. I have not opted to implement
this as I lack the knwoledge to make the changes required yet.

I tried 2 but the startup performance was quite bad and I suspect
the potential for breaking things is slightly higher than the last
two options.

I have implemented 3 and 4 so that Firefox 67 & >=68 can be
supported nicely in the same recipe.