### PR TITLE
Limit delete_blacklisted() function to only delete files from inside the current dir

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -120,10 +120,20 @@ delete_blacklisted()
 {
   BLACKLISTED_FILES=$(cat_file_from_url https://github.com/AppImage/pkg2appimage/raw/${PKG2AICOMMIT}/excludelist | sed 's|#.*||g')
   echo $BLACKLISTED_FILES
+
+  local DOT_DIR=$(readlink -f .)
+  local TARGET
   for FILE in $BLACKLISTED_FILES ; do
     FILES="$(find . -name "${FILE}" -not -path "./usr/optional/*")"
     for FOUND in $FILES ; do
-      rm -vf "$FOUND" "$(readlink -f "$FOUND")"
+      TARGET=$(readlink -f "$FOUND")
+
+      # Only delete files from inside the current dir.
+      if [[ $TARGET = $DOT_DIR/* ]]; then
+        rm -vf "$TARGET"
+      fi
+
+      rm -vf "$FOUND"
     done
   done
 


### PR DESCRIPTION
I recently tried building some appimage (I didn't make a note on which image it was) and got an error message from `rm` trying to remove some file under `/lib64/` something. Tracking the problem back it was the `delete_blacklisted()` function which removes both a file/symlink and its `readlink` expansion without any checks for the latter.

Here is a minimal test case, `Test.yml`. `libc.so.6` is blacklisted by default in `excludelist` so I make use of it below. **DONT BUILD THIS UNDER ROOT!!**

```yaml
app: test

ingredients:
  script:
    - echo dev > VERSION

script:
  - cat > test.desktop <<\EOF
  - [Desktop Entry]
  - Name=Test
  - Exec=test
  - Icon=test
  - Type=Application
  - Categories=Development;
  - EOF
  - touch test.png
  - ln -s /lib/x86_64-linux-gnu/libc.so.6

```

Last lines from the build log:

```
+ rm -vf ./libc.so.6 /lib/x86_64-linux-gnu/libc-2.19.so
removed ‘./libc.so.6’
rm: cannot remove ‘/lib/x86_64-linux-gnu/libc-2.19.so’: Permission denied
```
