### PR TITLE
Bash-only APT replacement

### DIFF
--- a/dogfeeding.sh
+++ b/dogfeeding.sh
@@ -9,7 +9,7 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 mkdir -p build/
 
 cd build/
-apt download -y apt libapt-pkg5.0 libbz2-1.0 liblzma5 multiarch-support zlib1g dpkg
+# apt download -y apt libapt-pkg5.0 libbz2-1.0 liblzma5 multiarch-support zlib1g dpkg
 
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$SYSTEM_ARCH.AppImage" # FIXME: Make arch independent
 wget -c "https://github.com/ImageMagick/ImageMagick/releases/download/7.0.8-17/ImageMagick-0b0ce48-gcc-$SYSTEM_ARCH.AppImage" # FIXME: Make arch independent
@@ -30,12 +30,12 @@ cp ./usr/share/applications/pkg2appimage.desktop .
 cp ../ImageMagick-*.AppImage usr/bin/convert
 
 # We don't suffer from NIH
-mkdir -p usr/src/
-wget -q "https://raw.githubusercontent.com/mikix/deb2snap/master/src/preload.c" -O - | \
-sed -e 's|SNAPPY|UNION|g' | sed -e 's|SNAPP|UNION|g' | sed  -e 's|SNAP|UNION|g' | \
-sed -e 's|snappy|union|g' > usr/src/libunionpreload.c
-gcc -shared -fPIC usr/src/libunionpreload.c -o libunionpreload.so -ldl -DUNION_LIBNAME=\"libunionpreload.so\"
-strip libunionpreload.so
+# mkdir -p usr/src/
+# wget -q "https://raw.githubusercontent.com/mikix/deb2snap/master/src/preload.c" -O - | \
+# sed -e 's|SNAPPY|UNION|g' | sed -e 's|SNAPP|UNION|g' | sed  -e 's|SNAP|UNION|g' | \
+# sed -e 's|snappy|union|g' > usr/src/libunionpreload.c
+# gcc -shared -fPIC usr/src/libunionpreload.c -o libunionpreload.so -ldl -DUNION_LIBNAME=\"libunionpreload.so\"
+# strip libunionpreload.so
 
 cp ../../pkg2appimage AppRun ; chmod + AppRun
 

--- a/functions.sh
+++ b/functions.sh
@@ -247,8 +247,9 @@ generate_type2_appimage()
   set +x
 
   GLIBC_NEEDED=$(glibc_needed)
-  _APP_DIR=$(readlink -f "./$APP.AppDir/")
-      
+  _APP_DIR="${PWD}/$APP.AppDir/"
+  export OWD="${PWD}"
+   
   if ( [ ! -z "$KEY" ] ) && ( ! -z "$TRAVIS" ) ; then
     wget https://github.com/AppImage/AppImageKit/files/584665/data.zip -O data.tar.gz.gpg
     ( set +x ; echo $KEY | gpg2 --batch --passphrase-fd 0 --no-tty --skip-verify --output data.tar.gz --decrypt data.tar.gz.gpg )

--- a/functions.sh
+++ b/functions.sh
@@ -358,3 +358,61 @@ patch_strings_in_file() {
         done
     fi
 }
+
+# Lightweight bash-only "apt update" and "apt download" replacement
+
+function apt-get.update(){
+  echo -n > cache.txt
+  while read line; do
+    local line=$(echo "${line}" | sed 's|[[:space:]]| |g')
+    local repo_info=($(echo ${line} | tr " " "\n"))
+    local base_url=${repo_info[1]}
+    local dist_name=${repo_info[2]}
+  
+    [ -f "Packages.gz" ] && {
+      cat Packages.gz | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" >> cache.txt
+    }
+  
+    for i in $(seq 3 $((${#repo_info[@]} - 1))); do
+      echo "Caching ${base_url} ${dist_name} ${repo_info[${i}]}..."
+      local repo_url="${base_url}/dists/${dist_name}/${repo_info[${i}]}/binary-amd64/Packages.gz"
+      wget -q ${repo_url} -O - | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" | sed "s|^Filename: |Filename: ${base_url}|g" >> cache.txt
+    done
+  done <sources.list
+}
+
+function apt-get.do-download(){
+  [ -f "status" ] && {
+    grep -q ^"Package: ${1}"$ status && return
+  }
+  
+  echo "${already_downloaded_package[@]}" | sed 's| |\n|g' | grep -q ^"${1}"$ && return
+  
+  already_downloaded_package+=(${1})
+   
+  local dependencies=($(cat cache.txt | grep -A 2 -m 1 ^"Package: ${1}"$    \
+                                      | grep ^"Depends: "                   \
+                                      | cut -c 9-                           \
+                                      | sed "s|([^)]*)||g;s|[[:space:]]||g" \
+                                      | sed "s|,|\n|g"                      \
+                                      | cut -d"|" -f1 ))
+
+  local package_url=$(cat cache.txt | grep -A 3 -m 1 ^"Package: ${1}"$ \
+                                    | grep ^"Filename: "               \
+                                    | cut -c 11-)
+  
+   
+  [ ! -f "${package_url}" ] && {
+    [ ! "${package_url}" = "" ] && {
+      wget -c "${package_url}"
+    } || {
+      echo ${1} >> teste_123
+    }
+  }
+  
+  unset package_url
+  
+  for depend in "${dependencies[@]}"; do
+    apt-get.do-download ${depend}
+  done
+}

--- a/functions.sh
+++ b/functions.sh
@@ -245,16 +245,19 @@ generate_type2_appimage()
   fi
 
   set +x
+
   GLIBC_NEEDED=$(glibc_needed)
+  _APP_DIR=$(readlink -f "./$APP.AppDir/")
+      
   if ( [ ! -z "$KEY" ] ) && ( ! -z "$TRAVIS" ) ; then
     wget https://github.com/AppImage/AppImageKit/files/584665/data.zip -O data.tar.gz.gpg
     ( set +x ; echo $KEY | gpg2 --batch --passphrase-fd 0 --no-tty --skip-verify --output data.tar.gz --decrypt data.tar.gz.gpg )
     tar xf data.tar.gz
     sudo chown -R $USER .gnu*
     mv $HOME/.gnu* $HOME/.gnu_old ; mv .gnu* $HOME/
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v "${_APP_DIR}"
   else
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v "${_APP_DIR}"
   fi
   set -x
   mkdir -p ../out/ || true

--- a/functions.sh
+++ b/functions.sh
@@ -363,15 +363,14 @@ patch_strings_in_file() {
 
 function apt-get.update(){
   echo -n > cache.txt
+  
+  cat Packages.gz | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" >> cache.txt || true
+  
   while read line; do
     local line=$(echo "${line}" | sed 's|[[:space:]]| |g')
     local repo_info=($(echo ${line} | tr " " "\n"))
     local base_url=${repo_info[1]}
     local dist_name=${repo_info[2]}
-  
-    [ -f "Packages.gz" ] && {
-      cat Packages.gz | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" >> cache.txt
-    }
   
     for i in $(seq 3 $((${#repo_info[@]} - 1))); do
       echo "Caching ${base_url} ${dist_name} ${repo_info[${i}]}..."

--- a/pkg2appimage
+++ b/pkg2appimage
@@ -269,15 +269,23 @@ if [ ! -z "${_ingredients_dist}" ] ; then
     INSTALL=${_ingredients_packages[@]}
   fi
 
-  apt-get -o Acquire::AllowInsecureRepositories=true -o Acquire::Languages="none" -o Acquire::AllowDowngradeToInsecureRepositories=true $OPTIONS update || true
-  URLS=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http") || true
-  if which aria2c &>/dev/null; then
-    dltool=aria2c
-  else
-    dltool=wget
-  fi
+#  apt-get -o Acquire::AllowInsecureRepositories=true -o Acquire::Languages="none" -o Acquire::AllowDowngradeToInsecureRepositories=true $OPTIONS update || true
+#  URLS=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http") || true
+#  if which aria2c &>/dev/null; then
+#    dltool=aria2c
+#  else
+#    dltool=wget
+#  fi
 
-  $dltool -c -i- <<<"$URLS"
+#  $dltool -c -i- <<<"$URLS"
+
+  apt-get.update
+  
+  INSTALL=($(echo "${INSTALL}" | sed "s| |\n|g"))
+  
+  for pkg in "${INSTALL}"; do
+    apt-get.do-download ${pkg}
+  done
 fi
 
 if [ ! -z "${_ingredients_post_script[0]}" ] ; then


### PR DESCRIPTION
Now with support local .deb files

* [prebuild AppImage](https://github.com/sudo-give-me-coffee/pkg2appimage/releases/download/no-apt-experimental-build/pkg2appimage-x86_64.AppImage)

Tested recipes:

* Scribus
* Leafpad
* Firefox
* Spotify