### PR TITLE
Adding intef-exe.yml for exelearning.net e-learning resources editor

### DIFF
--- a/recipes/intef-exe.yml
+++ b/recipes/intef-exe.yml
@@ -1,0 +1,22 @@
+app: intef-exe
+binpatch: true
+
+ingredients:
+  packages:
+    - intef-exe
+  dist: stable
+  sources:
+    - deb http://ftp.debian.org/debian/ stable main
+  exclude:
+    - firefox-esr
+    - iceweasel
+  script:
+    - DLD=$(wget -q "https://api.github.com/repos/exelearning/iteexe/releases/latest" -O - |grep "https.*all.deb"|cut -d'"' -f4)
+    - wget -c $DLD
+    - echo $DLD | cut -d "_" -f 2 > VERSION
+
+script:
+  - ln -s usr/share/applications/exe.desktop exe.desktop
+  - ln -s usr/share/icons/hicolor/48x48/apps/exe.png exe.png
+  - rm usr/lib/python2.7/sitecustomize.py
+  - mv etc/python2.7/sitecustomize.py usr/lib/python2.7/

--- a/recipes/intef-exe.yml
+++ b/recipes/intef-exe.yml
@@ -4,9 +4,9 @@ binpatch: true
 ingredients:
   packages:
     - intef-exe
-  dist: stable
+  dist: oldstable
   sources:
-    - deb http://ftp.debian.org/debian/ stable main
+    - deb http://ftp.debian.org/debian/ oldstable main
   exclude:
     - firefox-esr
     - iceweasel


### PR DESCRIPTION
Working recipe for [eXeLearning](https://exelearning.net/en/) educational editor ( repository [iteexe](https://github.com/exelearning/iteexe) on Github). Since it is a Python 2.7 application, an AppImage is a way of using it in recent Linux distros while the maintainers finish the transition to Python 3 (see [issue 95](https://github.com/exelearning/iteexe/issues/95) on their repo).
