### PR TITLE
Check and skip empty local APT repositories

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -280,9 +280,11 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   $dltool -c -i- <<<"$URLS"
 
   FILES=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^file" | cut -d ':' -f 2) || true
-  echo $FILES | while read file ; do
-    cp -s $file .
-  done
+  if [ ! -z "${FILES}" ] ; then
+    echo $FILES | while read file ; do
+      cp -s $file .
+    done
+  fi
 fi
 
 if [ ! -z "${_ingredients_post_script[0]}" ] ; then


### PR DESCRIPTION
fixes pkg2appimage fail when there are no local APT repositories which causes $FILES variable to be empty