### PR TITLE
Don't try to copy non-existing files.

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -280,9 +280,11 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   $dltool -c -i- <<<"$URLS"
 
   FILES=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^file" | cut -d ':' -f 2) || true
-  echo $FILES | while read file ; do
-    cp -s $file .
-  done
+  if [ -n "$FILES" ] ; then
+    echo $FILES | while read file ; do
+      cp -s $file .
+    done
+  fi
 fi
 
 if [ ! -z "${_ingredients_post_script[0]}" ] ; then


### PR DESCRIPTION
The recent change in pkg2appimage made it end up for me with this error:

+ FILES=
+ echo
+ read file
+ cp -s .
cp: missing destination file operand after '.'
Try 'cp --help' for more information.

This patch fixes that :-)