### PR TITLE
Add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN sed -i 's/archive.ubuntu.com/ftp.fau.de/g' /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y apt-transport-https libcurl3-gnutls libarchive13 wget desktop-file-utils aria2 fuse gnupg2 build-essential file libglib2.0-bin git && \
+    apt-get install -y apt-transport-https libcurl3-gnutls libarchive13 wget curl desktop-file-utils aria2 fuse gnupg2 build-essential file libglib2.0-bin git && \
     install -m 0777 -d /workspace
 
 RUN adduser --system --uid 1000 test


### PR DESCRIPTION
It seems some recipes use ``curl``, for example :

* [IntelliJ-IDEA-Community.yml](https://github.com/AppImage/pkg2appimage/blob/2688dbd4f015483cf3e96b0a8242f4ac37beb069/recipes/IntelliJ-IDEA-Community.yml)
* [PhpStorm.yml](https://github.com/AppImage/pkg2appimage/blob/2688dbd4f015483cf3e96b0a8242f4ac37beb069/recipes/PhpStorm.yml)
* [Rider.yml](https://github.com/AppImage/pkg2appimage/blob/2688dbd4f015483cf3e96b0a8242f4ac37beb069/recipes/Rider.yml)

But ``curl`` seems missing in ``Dockerfile`` (used by ``pkg2appimage-with-docker``) and resulting container.

```sh
curl https://raw.githubusercontent.com/AppImage/pkg2appimage/ea067c854f1cbae8b9118153b7954885df58e5f4/Dockerfile | docker build -
```

```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   551  100   551    0     0   1669      0 --:--:-- --:--:-- --:--:--  1664
Sending build context to Docker daemon   2.56kB
Step 1/6 : FROM ubuntu:trusty
 ---> 6e4f1fe62ff1
Step 2/6 : MAINTAINER "TheAssassin <theassassin@users.noreply.github.com>"
 ---> Using cache
 ---> 9a7daa4f07a5
Step 3/6 : ENV DEBIAN_FRONTEND=noninteractive     DOCKER_BUILD=1
 ---> Using cache
 ---> 10f50f19df65
Step 4/6 : RUN sed -i 's/archive.ubuntu.com/ftp.fau.de/g' /etc/apt/sources.list &&     apt-get update &&     apt-get install -y apt-transport-https libcurl3-gnutls libarchive13 wget desktop-file-utils aria2 fuse gnupg2 build-essential file libglib2.0-bin git &&     install -m 0777 -d /workspace
 ---> Using cache
 ---> 61ae83c599e1
Step 5/6 : RUN adduser --system --uid 1000 test
 ---> Using cache
 ---> 2c1c21d2739c
Step 6/6 : WORKDIR /workspace
 ---> Using cache
 ---> f97b6207af19
Successfully built f97b6207af19
```
```sh
docker run -it f97b6207af19 curl https://example.org/
```
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"curl\": executable file not found in $PATH": unknown.
ERRO[0000] error waiting for container: context canceled
```

``curl`` is missing.