### PR TITLE
fix pkg2appimage test ARCH environment variable

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -163,7 +163,7 @@ fi
 # and ingredients of that architecture. Debian packages
 # should be available for most architectures, e.g., oldstable
 # has "armhf"
-if [ ! -z $ARCH] ; then
+if [ ! -z "$ARCH" ] ; then
   OPTIONS="$OPTIONS -o APT::Architecture=$ARCH"
 fi
 


### PR DESCRIPTION
Fix a typo in ``pkg2appimage`` shell script.