### PR TITLE
Fix the extra dependencies is incomplete

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -286,7 +286,7 @@ if [ ! -z "${_ingredients_dist}" ] ; then
 
   apt-get.update
 
-  INSTALL=($(echo "${INSTALL}" | sed "s| |\n|g"))
+  INSTALL=$(echo "${INSTALL}" | sed "s| |\n|g")
 
   for pkg in "${INSTALL}"; do
     apt-get.do-download ${pkg}


### PR DESCRIPTION
Only the first package in `ingredients - packages` is bundled due to a syntax error in the script.