### PR TITLE
Fix the package in PPAs not downloaded

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -223,11 +223,11 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   if [ -e sources.list ] ; then
     rm sources.list
   fi
-  for SOURCE in "${_ingredients_sources[@]}" ; do
-    echo "${SOURCE}" >> sources.list
-  done
   for PPA in "${_ingredients_ppas[@]}" ; do
     echo "deb http://ppa.launchpad.net/${PPA}/ubuntu ${_ingredients_dist} main" >> sources.list
+  done
+  for SOURCE in "${_ingredients_sources[@]}" ; do
+    echo "${SOURCE}" >> sources.list
   done
   for DEBFILE in "${_ingredients_debs[@]}" ; do
     cp ${DEBFILE} .


### PR DESCRIPTION
I found that the ppa should be placed ahead of ubuntu's sources, or the newer version in ppa will not be download.