### PR TITLE
Fix syntax

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -288,7 +288,7 @@ if [ ! -z "${_ingredients_dist}" ] ; then
 
   INSTALL=$(echo "${INSTALL}" | sed "s| |\n|g")
 
-  for pkg in "${INSTALL}"; do
+  for pkg in ${INSTALL}; do
     apt-get.do-download ${pkg}
   done
 


### PR DESCRIPTION
Sorry I forget that the double quotes also need to be removed, or bash will parse INSTALL as a single variable...