### PR TITLE
Update Zoom.yml - Translations

### DIFF
--- a/recipes/Zoom.yml
+++ b/recipes/Zoom.yml
@@ -20,6 +20,7 @@ ingredients:
 
 script:
   - ( cd usr/bin/ ; rm -f * ; mv ../../opt/zoom/* . )
+  - sed -i 's/\.\.\/zoom\/translations\//\.\/\.\/\.\/\.\/translations\//g' usr/bin/zoom
   - sed -i -e 's|/usr/bin/zoom %U|ZoomLauncher %U|g' Zoom.desktop
   - sed -i -e 's|/usr/bin/zoom %U|ZoomLauncher %U|g' usr/share/applications/Zoom.desktop
   - ( cd usr/bin/ ; mv ../lib/x86_64-linux-gnu/* . )


### PR DESCRIPTION
Hello,

Translation does not work on Zoom.AppImage.

For the `usr/bin/zoom` file the translation folder is in `../zoom/translations/` while they are in `./translations/`.

To fix the problem I suggest replacing `../zoom/translations/` by `././././translations/` in the file `usr/bin/zoom`.