### PR TITLE
Fix missing libjs.so.0 error in 0ad

### DIFF
--- a/recipes/0ad.yml
+++ b/recipes/0ad.yml
@@ -11,3 +11,8 @@ ingredients:
 script:
   - find usr/lib/games/0ad/ -type f -iname '*.so.*' -exec mv {} usr/lib/ \;
   - mv usr/games/* usr/bin/
+  - mkdir -p usr/bin/share
+  - mv usr/share/games usr/bin/share
+  - sed -i 's#/usr#././#g' usr/bin/pyrogenesis
+  - sed -i '1a HERE=$(cd "$(dirname "$0")";pwd) && cd $HERE' usr/bin/0ad
+  - cp usr/lib/x86_64-linux-gnu/libmozjs-38.so.0.0.0 usr/lib/x86_64-linux-gnu/libjs.so.0


### PR DESCRIPTION
This solves half of https://github.com/AppImage/pkg2appimage/issues/294, applying the modification suggested to `0ad.yml` by @shouhuanxiaoji, but replacing the `ln -s` with a `cp`, because the symlink didn't work on my system.

The resulting package has been tested on Archlinux, Ubuntu 14.04 and Ubuntu 20.04.