### PR TITLE
Create Battle_for_Wesnoth.yml

### DIFF
--- a/recipes/Battle_for_Wesnoth.yml
+++ b/recipes/Battle_for_Wesnoth.yml
@@ -1,0 +1,21 @@
+app: Battle_for_Wesnoth
+
+ingredients:
+  packages:
+    - wesnoth
+    - wesnoth-music
+  dist: xenial
+  sources:
+    - deb http://archive.ubuntu.com/ubuntu/ xenial main universe security
+  ppas:
+    #- vincent-c/wesnoth
+    - pkg-games/wesnoth-devel
+
+script:
+  - mv usr/share/applications/wesnoth-?.??.desktop wesnoth.desktop
+  - mv usr/share/icons/hicolor/512x512/apps/wesnoth-icon.png wesnoth.png
+  - sed -i "s/^Icon=.*/Icon=wesnoth.png/" wesnoth.desktop
+  - sed -i "/^Exec=/s/-nolog//" wesnoth.desktop
+  - sed -i 's#/usr#././#g' usr/games/wesnoth-*
+  - for i in $(find usr/share/games/wesnoth/*/fonts/ -type l); do mv "$(readlink "$i" | sed "s|^/||")" "$i"; done
+  - rm -r etc usr/share/man usr/share/X11 usr/share/icons/hicolor usr/share/applications


### PR DESCRIPTION
Recipe for the classic game Battle for Wesnoth (https://www.wesnoth.org/)

Resulting AppImage works fine on ubuntu-16.04-desktop-amd64.iso, ubuntu-18.04.5-desktop-amd64.iso, ubuntu-20.04.1-desktop-amd64.iso and openSUSE-Leap-15.2-KDE-Live-x86_64-Build31.309-Media.iso

Doesn't work on Fedora-Workstation-Live-x86_64-33-1.2.iso, because it lacks libjack.so.0, but according to the `excludelist`, libjack.so.0 can't be added to the AppImage