### PR TITLE
Update kicad nightly recipe to new repo

### DIFF
--- a/recipes/KiCad-nightly.yml
+++ b/recipes/KiCad-nightly.yml
@@ -1,18 +1,18 @@
 # Might be necessary to bundle Python - to be investigated
 
-app: KiCad
+app: KiCad-nightly
 binpatch: true
 
 ingredients:
   packages:
-    - kicad
-    - kicad-library
+    - kicad-nightly
+    - kicad-library-all
     - libcurl3
-  dist: trusty
+  dist: bionic
   sources:
-    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
+    - deb http://archive.ubuntu.com/ubuntu/ bionic main universe
   ppas:
-    - js-reynaud/ppa-kicad
+    - kicad/kicad-dev-nightly
 
 script:
   - # Workaround until

--- a/recipes/KiCad-nightly.yml
+++ b/recipes/KiCad-nightly.yml
@@ -8,9 +8,9 @@ ingredients:
     - kicad-nightly
     - kicad-library-all
     - libcurl3
-  dist: focal
+  dist: bionic
   sources:
-    - deb http://archive.ubuntu.com/ubuntu/ focal main universe
+    - deb http://archive.ubuntu.com/ubuntu/ bionic main universe
   ppas:
     - kicad/kicad-dev-nightly
 

--- a/recipes/KiCad-nightly.yml
+++ b/recipes/KiCad-nightly.yml
@@ -8,9 +8,9 @@ ingredients:
     - kicad-nightly
     - kicad-library-all
     - libcurl3
-  dist: bionic
+  dist: focal
   sources:
-    - deb http://archive.ubuntu.com/ubuntu/ bionic main universe
+    - deb http://archive.ubuntu.com/ubuntu/ focal main universe
   ppas:
     - kicad/kicad-dev-nightly
 

--- a/recipes/KiCad-nightly.yml
+++ b/recipes/KiCad-nightly.yml
@@ -22,6 +22,6 @@ script:
   - HERE="$(dirname "$(readlink -f "${0}")")"
   - export LD_LIBRARY_PATH="${HERE}"/usr/lib/x86_64-linux-gnu/:"${HERE}"/lib/x86_64-linux-gnu/:"${HERE}"/usr/lib/:"${HERE}"/lib/:$LD_LIBRARY_PATH
   - cd "${HERE}/usr"
-  - exec "./bin/kicad" "$@"
+  - exec "./lib/kicad-nightly/bin/kicad" "$@"
   - EOF
   - chmod a+x ./AppRun


### PR DESCRIPTION
Couple of things changed since the old recipe was created:

- js-reynauds personal repo is deprecated and there now exists an official development repo
- KiCad now needs boost >=1.59, so it's not compatible with neither trusty nor xenial
- There's now a dedicated kicad-nightly package. The app name had to be changed in order for the binary and .destkop auto-detect to properly work

Let me know if I did something stupid. This is my first appimage recipe after all ;)