### PR TITLE
Make apt-get.update add an extra slash so the recipe doesn't have to

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -387,7 +387,7 @@ function apt-get.update(){
     for i in $(seq 3 $((${#repo_info[@]} - 1))); do
       echo "Caching ${base_url} ${dist_name} ${repo_info[${i}]}..."
       local repo_url="${base_url}/dists/${dist_name}/${repo_info[${i}]}/binary-amd64/Packages.gz"
-      wget -q ${repo_url} -O - | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" | sed "s|^Filename: |Filename: ${base_url}|g" >> cache.txt
+      wget -q "${repo_url}" -O - | gunzip -c | grep -E "^Package:|^Filename:|^Depends:|^Version:" | sed "s|^Filename: |Filename: ${base_url}/|g" >> cache.txt
     done
   done <sources.list
 }


### PR DESCRIPTION
Currently there's kind of an inconsistency on how pkg2appimage's apt replacement handles slashes. It adds a slash when downloading the Packages.gz file, but not when downloading DEBs themselves (which requires the recipe to have a URL ending in a slash).

This means, if the source URL is `archive.ubuntu.com/ubuntu`, it will download `archive.ubuntu.com/ubuntu/dists/xenial/main/Packages.gz` (OK), but then downloads `archive.ubuntu.com/ubuntupool/[...]/pkg.deb` (gets 404).

If the source URL is `archive.ubuntu.com/ubuntu/`, it will download `archive.ubuntu.com/ubuntu//dists/xenial/main/Packages.gz`, and downloads `archive.ubuntu.com/ubuntu/pool/[...]/pkg.deb` (OK).

This is not an issue with first-party Ubuntu and Debian repos/PPAs, which ignore double slashes, but causes issues for third-party software hosted on certain cloud providers:

Compare these two links:
https://brave-browser-apt-release.s3.brave.com/dists/stable/main/binary-amd64/Packages.gz (works)
https://brave-browser-apt-release.s3.brave.com//dists/stable/main/binary-amd64/Packages.gz (404s)

Currently, trying to make a Brave or Signal recipe will make either getting the Packages.gz file fail, or getting the DEBs themselves fail. This aims to fix this.