### PR TITLE
a fix for Blender.yml

### DIFF
--- a/recipes/Blender.yml
+++ b/recipes/Blender.yml
@@ -5,7 +5,7 @@ ingredients:
     - FILENAME=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 6 | cut -d "/" -f 3 | head -n 1)
     - VERSION=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 6 | cut -d "/" -f 2 | head -n 1)
     - echo "$VERSION" > VERSION
-    - wget "https://ftp.nluug.nl/pub/graphics/blender/release/$VERSION/$FILENAME"
+    - wget "https://download.blender.org/release/$VERSION/$FILENAME"
     - mkdir -p blender
     - tar xf blender*.tar.xz -C ./blender --strip-components=1
 

--- a/recipes/Blender.yml
+++ b/recipes/Blender.yml
@@ -2,10 +2,10 @@ app: Blender
 
 ingredients:
   script:
-    - FILENAME=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 6 | cut -d "/" -f 3 | head -n 1)
-    - VERSION=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 6 | cut -d "/" -f 2 | head -n 1)
+    - FILENAME=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 76 | cut -d "/" -f 6 | head -n 1)
+    - VERSION=$(wget -q "https://www.blender.org/download/" -O - | grep linux64 | cut -d '"' -f 76 | cut -d "/" -f 5 | head -n 1)
     - echo "$VERSION" > VERSION
-    - wget "https://download.blender.org/release/$VERSION/$FILENAME"
+    - wget "https://download.blender.org/release/$VERSION/$FILENAME" # $VERSION should look like 'Blender2.92' and $FILENAME should look like 'blender-2.92.0-linux64.tar.xz'
     - mkdir -p blender
     - tar xf blender*.tar.xz -C ./blender --strip-components=1
 


### PR DESCRIPTION
the script was not working again may have to find a new way to find the file.
+ Changed the downloade source to download.blender.org because it's the official main mirror, ftp.nluug.nl ist an official regional mirror