### PR TITLE
Added Factorio (demo) recipe

### DIFF
--- a/recipes/FactorioDemo.yml
+++ b/recipes/FactorioDemo.yml
@@ -6,7 +6,7 @@ ingredients:
   sources:
     - deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe
   script:
-    - VERSION=1.1.30
+    - VERSION=1.0.0
     - wget --continue --content-disposition "https://factorio.com/get-download/$VERSION/demo/linux64"
     - tar -xf "factorio_demo_x64_$VERSION.tar.xz"
     - echo "$VERSION" > VERSION

--- a/recipes/FactorioDemo.yml
+++ b/recipes/FactorioDemo.yml
@@ -1,0 +1,27 @@
+app: FactorioDemo
+binpatch: true
+
+ingredients:
+  dist: xenial
+  sources:
+    - deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe
+  script:
+    - VERSION=1.1.30
+    - wget --continue --content-disposition "https://factorio.com/get-download/$VERSION/demo/linux64"
+    - tar -xf "factorio_demo_x64_$VERSION.tar.xz"
+    - echo "$VERSION" > VERSION
+
+script:
+  - mv ../factorio/bin/x64/factorio usr/bin/
+  - mv ../factorio/data usr/share/factorio
+  - cp usr/share/factorio/core/graphics/factorio.png factorio.png
+
+  - cat > Factorio.desktop <<EOF
+  - [Desktop Entry]
+  - Type=Application
+  - Name=Factorio (demo)
+  - Comment=A game in which you build and maintain factories
+  - Exec=factorio
+  - Icon=factorio.png
+  - Categories=Game;
+  - EOF


### PR DESCRIPTION
Version 1.0.0 (http://download.sourceforge.net/pg4l/Factorio_(demo)-1.0.0.glibc2.18-x86_64.AppImage) was tested successfully on these distros:

- ubuntu-14.04.6-desktop-amd64.iso
- ubuntu-16.04.7-desktop-amd64.iso
- Fedora-Workstation-Live-x86_64-33-1.2.iso

Version 1.1.30 (http://download.sourceforge.net/pg4l/Factorio_(demo)-1.1.30.glibc2.18-x86_64.AppImage) was only tested on Linux Mint 19.1 because it doesn't work on my hardware, it's no longer compatible with my graphics card