### PR TITLE
VSCode: update url to update.code.visualstudio.com

### DIFF
--- a/recipes/VSCode.yml
+++ b/recipes/VSCode.yml
@@ -16,7 +16,7 @@ ingredients:
   sources: 
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   script:
-    - wget -c --trust-server-names "https://vscode-update.azurewebsites.net/latest/linux-deb-x64/stable"
+    - wget -c --trust-server-names "https://update.code.visualstudio.com/latest/linux-deb-x64/stable"
     - ls code_*.deb | cut -d _ -f 2 > VERSION
 
 script:


### PR DESCRIPTION
The old url is no longer working and has been replaced.
![imagen](https://user-images.githubusercontent.com/14185777/113493681-ef672980-94e1-11eb-9722-bb824bfe7e2d.png)
