### PR TITLE
Update to Wireshark 3.4.2

### DIFF
--- a/recipes/Wireshark.yml
+++ b/recipes/Wireshark.yml
@@ -1,9 +1,9 @@
 app: Wireshark
 
 ingredients:
-  dist: trusty
+  dist: focal
   sources: 
-    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
+    - deb http://archive.ubuntu.com/ubuntu/ focal main universe
   ppas: 
     - wireshark-dev/stable
 


### PR DESCRIPTION
Update to Wireshark Git v3.4.2 packaged as 3.4.2-1~ubuntu20.04.0+wiresharkdevstable1 from ubuntu 20.04