### PR TITLE
MonoDevelop: fixed the YAML recipe

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -361,7 +361,7 @@ fi
 # main *.exe to usr/lib/mono/exe, because we move all "assemblies" (sic)
 # there in this script
 
-if [ -e usr/lib/mono ] ; then
+if [ -e usr/lib/mono -a ! -e ../mono_no_squash.flag ] ; then
   # Force all so files referenced in config files into LD_LIBRARY_PATH
   find . -name "*.dll.config" -exec cat {} > temp \;
   # Remove all absolute paths

--- a/recipes/MonoDevelop.yml
+++ b/recipes/MonoDevelop.yml
@@ -20,52 +20,39 @@ ingredients:
     - monodoc-manual
   pretend:
     - libgtk2.0-0 2.24.10-2
+  post:
+    script:
+      - touch mono_no_squash.flag
 
 script:
-    - rm AppRun || true
-    - cat > AppRun <<\EOF
-    - #!/bin/bash
-    - # Based on
-    - # https://stackoverflow.com/a/15179369
-    - HERE="$(dirname "$(readlink -f "${0}")")"
-    - PKG_DIR=$HERE/usr
-    - set -x
-    - export LD_LIBRARY_PATH=$PKG_DIR/lib64:$PKG_DIR/lib:$LD_LIBRARY_PATH
-    - #export LD_RUN_PATH=$LD_LIBRARY_PATH
-    - export PKG_CONFIG_PATH=$PKG_DIR/lib64/pkgconfig:$PKG_CONFIG_PATH
-    - export MONO_GAC_PREFIX=${PKG_DIR}
-    - export MONO_PATH=${PKG_DIR}/lib/mono/4.0:\
-    - ${PKG_DIR}/lib/mono/fsharp:\
-    - ${PKG_DIR}/lib/mono/lldb:\
-    - ${PKG_DIR}/lib/mono/'Microsoft F#':\
-    - ${PKG_DIR}/lib/mono/'Microsoft SDKs':\
-    - ${PKG_DIR}/lib/mono/mono-configuration-crypto:\
-    - ${PKG_DIR}/lib/mono/monodoc:\
-    - ${PKG_DIR}/lib/mono/msbuild:\
-    - ${PKG_DIR}/lib/mono/xbuild:\
-    - ${PKG_DIR}/lib/mono/xbuild-frameworks:\
-    - ${PKG_DIR}/lib/mono/4.7-api:\
-    - ${PKG_DIR}/lib/mono/4.7.1-api:\
-    - ${PKG_DIR}/lib/mono/4.6-api:\
-    - ${PKG_DIR}/lib/mono/4.6.2-api:\
-    - ${PKG_DIR}/lib/mono/4.6.1-api:\
-    - ${PKG_DIR}/lib/mono/4.5-api:\
-    - ${PKG_DIR}/lib/mono/4.5.2-api:\
-    - ${PKG_DIR}/lib/mono/4.5.1-api:\
-    - ${PKG_DIR}/lib/mono/4.5:\
-    - ${PKG_DIR}/lib/mono/4.0-api:\
-    - ${PKG_DIR}/lib/mono/4.0:\
-    - ${PKG_DIR}/lib/mono/3.5-api:\
-    - ${PKG_DIR}/lib/mono/2.0-api:\
-    - ${PKG_DIR}/lib/monodevelop
-    - export MONO_CONFIG=${HERE}/etc/mono/config
-    - export MONO_CFG_DIR=${HERE}/etc
-    - export C_INCLUDE_PATH=${PKG_DIR}/include
-    - export ACLOCAL_PATH=${PKG_DIR}/share/aclocal
-    - export FONTCONFIG_PATH=${HERE}/etc/fonts
-    - export MONO_REGISTRY_PATH=~/.mono/registry
-    - export PATH=$HERE/bin:$PKG_DIR/bin:$PKG_DIR/lib/monodevelop/bin:$PATH
-    - export EXE_PATH=$PKG_DIR/lib/monodevelop/bin
-    - exec monodevelop "$@"
-    - EOF
-    - chmod +x AppRun
+  - cp usr/share/icons/hicolor/scalable/apps/monodevelop.svg .
+  - cp usr/share/icons/hicolor/48x48/apps/monodevelop.png .
+  - mkdir usr/lib/cli-all
+  - cp $(find usr/lib/cli -name \*.dll -o -name \*.so -o -name \*.so.\*) usr/lib/cli-all/
+  - cp $(find usr/lib/cli -name \*.config) usr/lib/cli-all/
+  - sed -i -e 's|target='$(printf '\042')'/.*/\([^'$(printf '\042')']\+\)'$(printf '\042')'|target='$(printf '\042')'\1'$(printf '\042')'|g' $(find usr/lib/cli-all -name \*.config)
+  - sed -i -e 's|Exec=monodevelop|Exec=AppRun|g' monodevelop.desktop
+  - rm AppRun || true
+  - cat > AppRun <<\EOF
+  - #!/bin/bash
+  - # Based on
+  - # https://stackoverflow.com/a/15179369
+  - HERE=$(dirname $(readlink -f "${0}"))
+  - PKG_DIR=$HERE/usr
+  - set -x
+  - export LD_LIBRARY_PATH=$PKG_DIR/lib64:$PKG_DIR/lib:$LD_LIBRARY_PATH
+  - #export LD_RUN_PATH=$LD_LIBRARY_PATH
+  - export PKG_CONFIG_PATH=$PKG_DIR/lib64/pkgconfig:$PKG_CONFIG_PATH
+  - export MONO_GAC_PREFIX=${PKG_DIR}
+  - export MONO_PATH=${PKG_DIR}/lib/mono/4.0-api:${PKG_DIR}/lib/mono/4.0:${PKG_DIR}/lib/mono/fsharp:${PKG_DIR}/lib/mono/lldb:${PKG_DIR}/lib/mono/'Microsoft F#':${PKG_DIR}/lib/mono/'Microsoft SDKs':${PKG_DIR}/lib/mono/mono-configuration-crypto:${PKG_DIR}/lib/mono/monodoc:${PKG_DIR}/lib/mono/msbuild:${PKG_DIR}/lib/mono/xbuild:${PKG_DIR}/lib/mono/xbuild-frameworks:${PKG_DIR}/lib/mono/4.7-api:${PKG_DIR}/lib/mono/4.7.1-api:${PKG_DIR}/lib/mono/4.6-api:${PKG_DIR}/lib/mono/4.6.2-api:${PKG_DIR}/lib/mono/4.6.1-api:${PKG_DIR}/lib/mono/4.5-api:${PKG_DIR}/lib/mono/4.5.2-api:${PKG_DIR}/lib/mono/4.5.1-api:${PKG_DIR}/lib/mono/4.5:${PKG_DIR}/lib/mono/4.0-api:${PKG_DIR}/lib/mono/4.0:${PKG_DIR}/lib/mono/3.5-api:${PKG_DIR}/lib/mono/2.0-api:${PKG_DIR}/lib/monodevelop:${PKG_DIR}/lib/cli-all
+  - export MONO_CONFIG=${HERE}/etc/mono/config
+  - export MONO_CFG_DIR=${HERE}/etc
+  - export C_INCLUDE_PATH=${PKG_DIR}/include
+  - export ACLOCAL_PATH=${PKG_DIR}/share/aclocal
+  - export FONTCONFIG_PATH=${HERE}/etc/fonts
+  - export MONO_REGISTRY_PATH=~/.mono/registry
+  - export PATH=$HERE/bin:$PKG_DIR/bin:$PKG_DIR/lib/monodevelop/bin:$PATH
+  - export EXE_PATH=$PKG_DIR/lib/monodevelop/bin
+  - exec monodevelop "$@"
+  - EOF
+  - chmod +x AppRun


### PR DESCRIPTION
Kind of works now.

* [x] Build succeeds
* [x] The IDE starts
* [x] Solution/project creation succeeds
* [x] Build succeeds
* [ ] Debugging works

The debugger still fails unfortunately. I'm not sure it's related to AppImage because when I run AppRun directly from build location it fails as well. Probably related: https://askubuntu.com/questions/1064146/monodevelop-fails-to-connect-debugger-when-not-running-as-sudo

Also, I'm not sure that using a marker file (`mono_no_squash.flag`) to disable Mono library squashing is a good idea.