### PR TITLE
Update wps-office.yml

### DIFF
--- a/recipes/wps-office.yml
+++ b/recipes/wps-office.yml
@@ -1,12 +1,14 @@
 # Wps office appimage 
 # Author linlinger
 # Date Fri Jan 22 2021
+# Updated on Thu Jan6 2022
 app: wps-office
 
 ingredients:
   packages:
     - libc6(>= 2.15)
     - libc6.1
+    - libstdc++6 (>= 4.6)
     - libfreetype6(>= 2.4)
     - libcups2
     - libglib2.0-0
@@ -22,7 +24,7 @@ ingredients:
   sources: 
     - deb http://us.archive.ubuntu.com/ubuntu/ bionic  main restricted universe multiverse
   script:
-    - wget https://wdl1.cache.wps.cn/wps/download/ep/Linux2019/10161/wps-office_11.1.0.10161_amd64.deb
+    - wget https://wdl1.cache.wps.cn/wps/download/ep/Linux2019/10702/wps-office_11.1.0.10702_amd64.deb
 
 script:
   - cp ./usr/share/applications/wps-office-prometheus.desktop ./


### PR DESCRIPTION
Keep WPS Office up to date. Should work well on Ubuntu 18.04LTS and up. Tested on Ubuntu 20.04LTS