### PR TITLE
Do not exclude libgobject

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -168,9 +168,6 @@ libuuid.so.1
 # libwind.so.0 # Missing on openSUSE LEAP 42.0
 libz.so.1
 
-# Potentially dangerous libraries
-libgobject-2.0.so.0
-
 # Workaround for:
 # Rectangles instead of fonts
 # https://github.com/AppImage/AppImages/issues/240


### PR DESCRIPTION
As libglib isn't excluded anymore, we need to fully allow libgobject in appimages as well.

Remove previous libgobject exclusion from the excludelist.